### PR TITLE
Continue tracking test-tree/misc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
-test-tree/
+test-tree/*
+!test-tree/misc/
 __pycache__
 venv


### PR DESCRIPTION
Removed this directory from tracking by error since most other folders in test-tree don't require tracking.

Reinstating.