### PR TITLE
Record run time for complete upload/download operation

### DIFF
--- a/test-download.py
+++ b/test-download.py
@@ -5,11 +5,16 @@ from utils import log, parse_cli, rclone_download
 DOWNLOAD_DIR = "test-tree/downloads"
 
 import os
+import datetime
+
 
 def main():
     # Do some initial setup, parse cli, etc
     cli = parse_cli()
+    start_time = datetime.datetime.now()
     rclone_download(os.path.join(DOWNLOAD_DIR, cli.remote_dir), cli.remote_dir)
+    elapsed_time = datetime.datetime.now() - start_time
+    log(f"Last download run completed in {elapsed_time}...")
 
 if __name__ == "__main__":
     main()

--- a/upload-test.py
+++ b/upload-test.py
@@ -3,6 +3,7 @@
 from utils import log, parse_cli, rclone_upload
 import os
 import sys
+import datetime
 
 CHALLENGING_NAMES_DIR = "test-tree/challenging-names"
 APOD_DIR = "test-tree/apod"
@@ -41,7 +42,7 @@ def skip_p(fname, cli):
 def main():
     # Do some initial setup, parse cli, etc
     cli = parse_cli()
-
+    start_time = datetime.datetime.now()
     if os.path.abspath(cli.directory) == os.path.abspath(CHALLENGING_NAMES_DIR):
         # Step through all the filenames and try to upload each one
         for fname in gentree.fname_permutations():
@@ -69,6 +70,8 @@ def main():
         rclone_upload(NESTED_DIR, cli.remote_dir, timeout=0)
     else:
         sys.exit("Not sure what to do with that directory.")
+    elapsed_time = datetime.datetime.now() - start_time
+    log(f"Last upload run completed in {elapsed_time}...")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Currently there's timing that measures how much time each file takes to upload or download.

With this commit, we can get the run time for a complete upload or download run (that is time taken to upload mutilple files and folders).