### PR TITLE
Prevent partial uploads

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -72,6 +72,7 @@ def rclone_upload(fname, remote_dir, timeout: int = TIMEOUT):
             "-vv",
             "--size-only",  # server doesn't do mtime
             "--sftp-set-modtime=false",  # server doesn't do mtime
+            "--inplace",
             fname,
             f"{RCLONE_REMOTE}:{ARCHIVE_PATH}{remote_dir}",
         ]


### PR DESCRIPTION
The new version of rclone defaults of partial uploads that get renamed.

Since we do not support renaming we want to prevent this behavoir.

See: https://github.com/rclone/rclone/issues/3770